### PR TITLE
FIX: Remove Top-Level Method

### DIFF
--- a/lib/aliyunsdkcore/roa_client.rb
+++ b/lib/aliyunsdkcore/roa_client.rb
@@ -2,10 +2,6 @@ require 'faraday'
 require 'securerandom'
 require 'active_support/all'
 
-def present?(obj)
-  obj.respond_to?(:empty?) ? !obj.empty? : obj
-end
-
 module AliyunSDKCore
 
   class ROAClient
@@ -29,7 +25,7 @@ module AliyunSDKCore
 
       response = connection.send(method.downcase) do |request|
         request.url uri, params
-        if present?(body)
+        if body.try(:any?) || body
           request_body                  = body.to_json
           request.body                  = request_body
           mix_headers['content-md5']    = Digest::MD5.base64digest request_body
@@ -88,7 +84,7 @@ module AliyunSDKCore
         'x-acs-signature-version' => '1.0',
         'x-acs-version' =>           self.api_version,
         'x-sdk-client' =>            "RUBY(#{RUBY_VERSION})", # FIXME: 如何获取Gem的名称和版本号
-        'user-agent' => DEFAULT_UA
+        'user-agent' =>              DEFAULT_UA
       }
       if self.security_token
         default_headers.merge!(

--- a/lib/aliyunsdkcore/rpc_client.rb
+++ b/lib/aliyunsdkcore/rpc_client.rb
@@ -3,15 +3,6 @@ require 'openssl'
 require 'faraday'
 require 'active_support/all'
 
-# Converts just the first character to uppercase.
-#
-#   upcase_first('what a Lovely Day') # => "What a Lovely Day"
-#   upcase_first('w')                 # => "W"
-#   upcase_first('')                  # => ""
-def upcase_first(string)
-  string.length > 0 ? string[0].upcase.concat(string[1..-1]) : ""
-end
-
 module AliyunSDKCore
 
   class RPCClient
@@ -68,6 +59,15 @@ module AliyunSDKCore
     end
 
     private
+
+    # Converts just the first character to uppercase.
+    #
+    #   upcase_first('what a Lovely Day') # => "What a Lovely Day"
+    #   upcase_first('w')                 # => "W"
+    #   upcase_first('')                  # => ""
+    def upcase_first(string)
+      string.length > 0 ? string[0].upcase.concat(string[1..-1]) : ""
+    end
 
     def connection(adapter = Faraday.default_adapter)
       Faraday.new(:url => self.endpoint) { |faraday| faraday.adapter adapter }


### PR DESCRIPTION
方法 `present?` 和 `upcase_first` 被作为 top-level method 声明，引入（require）后会污染全局的同名方法。