### PR TITLE
Fixed an issue that caused a StandardError when BatchCheckDeviceNames was successfully requested

### DIFF
--- a/lib/aliyunsdkcore/rpc_client.rb
+++ b/lib/aliyunsdkcore/rpc_client.rb
@@ -51,7 +51,7 @@ module AliyunSDKCore
       end
 
       response_body = JSON.parse(response.body)
-      if response_body['Code'] && !self.codes.include?(response_body['Code'])
+      if response_body['Code'] && !response_body['Code'].to_s.empty? && !self.codes.include?(response_body['Code'])
         raise StandardError, "#{response_body['Message']}, URL: #{uri}"
       end
 

--- a/spec/rpc_client_spec.rb
+++ b/spec/rpc_client_spec.rb
@@ -167,6 +167,14 @@ describe 'RPCClient' do
         rpc_client.request(action: 'action')
       }.to raise_error(StandardError, /error message, URL:/)
     end
+
+    it 'request with no problem should be ok' do
+      mock_response = { Code: "" }.to_json
+      stub_request(:get, /https:\/\/ecs.aliyuncs.com/).to_return(status: 200, body: mock_response)
+      expect {
+        rpc_client.request(action: 'action')
+      }.to_not raise_error(StandardError)
+    end
   end
 
   describe 'RPC private methods' do


### PR DESCRIPTION
Fixed an issue that caused a StandardError when BatchCheckDeviceNames was successfully requested.

sample.rb
```ruby
require 'aliyunsdkcore'

client = RPCClient.new(
  access_key_id:     'xxxx',
  access_key_secret: 'xxxx',
  endpoint: 'http://iot.ap-northeast-1.aliyuncs.com',
  api_version: '2018-01-20'
)

response = client.request(
  action: 'BatchCheckDeviceNames',
  params: {
    "RegionId": "ap-northeast-1",
    "ProductKey": "xxxx",
    "DeviceName.1": "test1",
    "DeviceName.2": "test2"
},
  opts: {
    method: 'POST'
  }
)

print response
```

In this case, the response.body['Code'] is a "", but the StandardError is raised.

##### You need to complete

- [x] unit tests and/or feature tests
