### PR TITLE
Allow non-string parameters to be used

### DIFF
--- a/lib/aliyunsdkcore/rpc_client.rb
+++ b/lib/aliyunsdkcore/rpc_client.rb
@@ -88,6 +88,7 @@ module AliyunSDKCore
     end
 
     def encode(string)
+      string = string.to_s unless string.is_a?(String)
       encoded = CGI.escape string
       encoded.gsub(/[\+]/, '%20')
     end


### PR DESCRIPTION
Because all `params` of `client.request` are encoded, passing a non-String value to params will result in an error.

sample.rb

```
require 'aliyunsdkcore'

client = RPCClient.new(
  access_key_id:     'xxxx',
  access_key_secret: 'xxxx',
  endpoint: 'http://iot.ap-northeast-1.aliyuncs.com',
  api_version: '2018-01-20'
)

response = client.request(
  action: 'BatchCheckDeviceNames',
  params: {
    "RegionId": "ap-northeast-1",
    "ProductKey": "xxxx",
    "DeviceName.1": "test1",
    "DeviceName.2": "test2"
  },
  opts: {
    method: 'POST'
  }
)

p response
p apply_id = response['Data']['ApplyId']

response = client.request(
  action: 'BatchRegisterDeviceWithApplyId',
  params: {
    "RegionId": "ap-northeast-1",
    "ApplyId": apply_id,
    "ProductKey": "xxxx"
  },
  opts: {
    method: 'POST'
  }
)

p response
p apply_id = response['Data']['ApplyId']
```

output

```
{"RequestId"=>"xxxx", "Data"=>{"ApplyId"=>xxxx}, "Code"=>"", "Success"=>true}
{"RequestId"=>"xxxx", "Data"=>{"ApplyId"=>xxxx}, "Code"=>"", "Success"=>true}
xxxx
Traceback (most recent call last):
        7: from test.rb:26:in `<main>'
        6: from /Users/yokazaki/.rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aliyunsdkcore-0.0.13/lib/aliyunsdkcore/rpc_client.rb:34:in `request'
        5: from /Users/yokazaki/.rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aliyunsdkcore-0.0.13/lib/aliyunsdkcore/rpc_client.rb:129:in `normalize'
        4: from /Users/yokazaki/.rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aliyunsdkcore-0.0.13/lib/aliyunsdkcore/rpc_client.rb:129:in `map'
        3: from /Users/yokazaki/.rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aliyunsdkcore-0.0.13/lib/aliyunsdkcore/rpc_client.rb:129:in `each'
        2: from /Users/yokazaki/.rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aliyunsdkcore-0.0.13/lib/aliyunsdkcore/rpc_client.rb:129:in `block in normalize'
        1: from /Users/yokazaki/.rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aliyunsdkcore-0.0.13/lib/aliyunsdkcore/rpc_client.rb:93:in `encode'
/Users/yokazaki/.rbenv/versions/2.5.7/lib/ruby/gems/2.5.0/gems/aliyunsdkcore-0.0.13/lib/aliyunsdkcore/rpc_client.rb:93:in `escape': no implicit conversion of Integer into String (TypeError)
```

By converting params to String once at the time of encode, you can pass a non-String value to params.

##### You need to complete

- [x] unit tests and/or feature tests
