### PR TITLE
pick up error code from failed response

### DIFF
--- a/lib/aliyunsdkcore/rpc_client.rb
+++ b/lib/aliyunsdkcore/rpc_client.rb
@@ -52,7 +52,7 @@ module AliyunSDKCore
 
       response_body = JSON.parse(response.body)
       if response_body['Code'] && !response_body['Code'].to_s.empty? && !self.codes.include?(response_body['Code'])
-        raise StandardError, "#{response_body['Message']}, URL: #{uri}"
+        raise StandardError, "Code: #{response_body['Code']}, Message: #{response_body['Message']}, URL: #{uri}"
       end
 
       response_body

--- a/spec/rpc_client_spec.rb
+++ b/spec/rpc_client_spec.rb
@@ -165,7 +165,7 @@ describe 'RPCClient' do
       stub_request(:get, /https:\/\/ecs.aliyuncs.com/).to_return(status: 400, body: mock_response)
       expect {
         rpc_client.request(action: 'action')
-      }.to raise_error(StandardError, /error message, URL:/)
+      }.to raise_error(StandardError, /Code: 400, Message: error message, URL:/)
     end
 
     it 'request with no problem should be ok' do


### PR DESCRIPTION
If the request fails, the caller decides what to do next, depending on the value of the Code.

However, the current client does not include the value of Code in the error message. The error message should also include a Code value.

##### You need to complete

- [x] unit tests and/or feature tests
